### PR TITLE
fix: updated MUI peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsksmart/rif-ui",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "Exposes common components to be re used in RIF projects",
   "keywords": [
     "RIF",
@@ -35,7 +35,7 @@
     "predeploy": "cd example && npm install && npm run build"
   },
   "devDependencies": {
-    "@material-ui/core": "^4.10.0",
+    "@material-ui/core": "^4.11.0",
     "@material-ui/icons": "^4.9.1",
     "@types/jest": "^26.0.0",
     "@types/react": "^16.9.35",
@@ -60,7 +60,7 @@
     "web3": "^1.2.8"
   },
   "peerDependencies": {
-    "@material-ui/core": "^4.10.0",
+    "@material-ui/core": "^4.11.0",
     "@material-ui/icons": "^4.9.1",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",


### PR DESCRIPTION
This PR updates Material-UI peer dependency to 4.11.0.
We already adapted the library to this new version by renaming `ExpansionPanels` to `Accordions`, but as I forgot to update the peer dependency on #104, the clients of our library (i.e. marketplace-ui) were still having the console error as they were falling back to that previous version