### PR TITLE
Removed unsupported node version 13 and added 14 on CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,9 +65,15 @@ workflows:
       - node-tests:
           version: '10'
           name: node-10
+          requires:
+            - check
       - node-tests:
           version: '12'
           name: node-12
+          requires:
+            - check
       - node-tests:
-          version: '13'
-          name: node-13
+          version: '14'
+          name: node-14
+          requires:
+            - check


### PR DESCRIPTION
## Problem
We are running CircleCI against node v13 (not supported anymore) and not against v14 (active version)

## Solution
Update the CircleCI config

## Related information
[NodeJS releases](https://nodejs.org/en/about/releases/)